### PR TITLE
Fixed ios_version_check for iOS 10 by parsing the strings to ints

### DIFF
--- a/depictions/js/ios_version_check.js
+++ b/depictions/js/ios_version_check.js
@@ -16,7 +16,11 @@ function ios_version_check(minIOS,maxIOS,otherIOS,callBack) {
 
 	function parseVersionString(version) {
 		var bits = version.split(".");
-		return [ bits[0], bits[1] ? bits[1] : 0, bits[2] ? bits[2] : 0 ];
+		return [ 
+				parseInt(bits[0], 10), 
+				parseInt(bits[1] ? bits[1] : 0, 10), 
+				parseInt(bits[2] ? bits[2] : 0, 10)
+			   ];
 	}
 
 	function compareVersions(one, two) {
@@ -47,7 +51,11 @@ function ios_version_check(minIOS,maxIOS,otherIOS,callBack) {
 		return 0;
 	}
 
-	var osVersion = [ version[2], version[3], version[4] ? version[5] : 0 ],
+	var osVersion = [ 
+						parseInt(version[2], 10), 
+						parseInt(version[3], 10), 
+						parseInt(version[4] ? version[5] : 0, 10)
+					],
 
 		osString = osVersion[0] + "." + osVersion[1] + (osVersion[2] && osVersion[2] != 0 ? "." + osVersion[2] : ""),
 		minString = minIOS,


### PR DESCRIPTION
This should fix the issue of ios_version_check causing issues when on iOS 10. The issue was occurring because it was doing string comparison but instead you want int comparison. You can of course get away with parsing the values in the comparison function but I prefer to just save it as int as that is what that variable is used for.